### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,17 @@ VERSION = 0.0.1
 CFLAGS = -Wall -Wextra
 LDFLAGS = -lm
 
-DESTDIR = /usr/local/bin
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
 
-hellcard: hellcard.c
-	$(CC) $(CFLAGS) hellcard.c -o hellcard $(LDFLAGS)
-
-debug: hellcard.c
-	$(CC) $(CFLAGS) -ggdb hellcard.c -o hellcard $(LDFLAGS)
+all: hellcard
 
 clean:
-	rm hellcard
+	rm -f hellcard
 
-install: hellcard
-	mkdir -p $(DESTDIR)
-	cp -f hellcard $(DESTDIR)
-	chmod 755 $(DESTDIR)/hellcard # chmod u=rwx,g=rx,o=rx
+install:
+	mkdir -p $(DESTDIR)$(BINDIR)
+	cp -p hellcard $(DESTDIR)$(BINDIR)
 
 uninstall:
 	rm -f $(DESTDIR)/hellcard
@@ -25,4 +21,4 @@ uninstall:
 release: hellcard
 	tar czf hellcard-v$(VERSION).tar.gz hellcard
 
-.PHONY: hellcard debug release clean install uninstall
+.PHONY: all clean install release uninstall


### PR DESCRIPTION
- `DESTDIR` is a variable designed for software packager (used to create a fakeroot directory)
- `PREFIX` / `BINDIR` are more common as variables names
- No need to define a `hellcard` target nor compiler rules, there are already predefined
- Traditional Makefiles usually come with a default `all` target

More subjective:

Targets designed for changing CFLAGS to add debug stuff is usually not a good idea because it means you can't compile a specific target that way. Usually a `-include config.mk` at the top of the makefile is better or use of conditionals (but that requires GNU make then).